### PR TITLE
corrected import statement

### DIFF
--- a/bktree/__init__.py
+++ b/bktree/__init__.py
@@ -1,1 +1,1 @@
-from bktree.bktree import Node, Tree
+from bktree import Node, Tree


### PR DESCRIPTION
While trying to import, current implementation throws ImportError:
`/usr/local/lib/python2.7/dist-packages/bktree/__init__.py in <module>()`
`----> 1 from bktree.bktree import Node, Tree`
`ImportError: No module named bktree`

Since we are importing from bktree.py file, import statement should be:

```
from bktree import Tree, Node
```
